### PR TITLE
Add endpoint to search for musicians based on partial name string

### DIFF
--- a/app/adapter.py
+++ b/app/adapter.py
@@ -56,6 +56,15 @@ class GraphAdapter():
 
         return rel_list
 
+    def generate_artists_list(self, artists_response) -> Artist:
+        print(artists_response)
+        # artist_dict = artists_response
+        # return Artist(artist_dict['name'], artist_dict['artistId'])
+
+    # Converts a list of relationships to a linear path from the given source
+    # name to the given destination name
+    def relationship_list_to_path(self, path, source, dest) -> Path:
+        pass
     # Converts a shortestPath neo4j query response into a list of relationships
     # containing a start node, relation and end node
     def generate_relationship_list(self, path_cursor) -> list:

--- a/app/main.py
+++ b/app/main.py
@@ -93,7 +93,7 @@ class ReleaseApi(Resource):
 
 api.add_resource(ArtistsIdApi, '/artists/<int:artist_id>')
 api.add_resource(ArtistsNameApi, '/artists/<string:artist_name>')
-api.add_resource(ArtistsSearchApi, '/artists/<string:querystring>')
+api.add_resource(ArtistsSearchApi, '/artists/search/<string:querystring>')
 api.add_resource(PathApi, '/path')
 api.add_resource(ReleaseApi, '/release/<int:release_id>')
 

--- a/app/main.py
+++ b/app/main.py
@@ -91,9 +91,9 @@ class ReleaseApi(Resource):
         else:
             return result
 
-api.add_resource(ArtistIdApi, '/artists/<int:artist_id>')
-api.add_resource(ArtistNameApi, '/artists/<string:artist_name>')
-api.add_resource(ArtistSearchApi, '/artists/<string:querystring>')
+api.add_resource(ArtistsIdApi, '/artists/<int:artist_id>')
+api.add_resource(ArtistsNameApi, '/artists/<string:artist_name>')
+api.add_resource(ArtistsSearchApi, '/artists/<string:querystring>')
 api.add_resource(PathApi, '/path')
 api.add_resource(ReleaseApi, '/release/<int:release_id>')
 

--- a/app/repository.py
+++ b/app/repository.py
@@ -67,16 +67,11 @@ class GraphRepository():
         :rtype: List of Artist
         """
 
-        artists_response = self._matcher.match("Artist").where("_.name =~ '{querystring}*'").order_by("_.name").limit(5)
-        print("REPOSITORY TIME")
-        print(artists_response)
-        pdb.set_trace()
-        if artists_response is None:
+        search_response = self._node_matcher.match("Artist", name__startswith=querystring).limit(5).order_by("_.name")
+        if search_response is None:
             return None
         else:
-            #TODO ITERATE THROUGH THE ARTISTS RESPONSE
-            #see neo4j docs for iter()
-            return self._adapter.generate_artists_list(artists_response)
+            return [self._adapter.generate_artist(x) for x in search_response]
 
     def get_path_by_id(self, artist_id_one: str, artist_id_two: str) -> Path:
         """get_path_by_id

--- a/app/repository.py
+++ b/app/repository.py
@@ -50,8 +50,7 @@ class GraphRepository():
         :rtype: Artist
         """
 
-        artist_response = self._matcher.match("Artist", name=artist_name)
-
+        artist_response = self._node_matcher.match("Artist", name=artist_name)
         if artist_response is None:
             return None
         else:
@@ -102,7 +101,7 @@ class GraphRepository():
 
     def get_release_by_id(self, release_id: str) -> Release:
         """get_release_by_id
-        
+
         :param release_id: The id of the release to be retrieved
         :type release_id: str
         :return: The release object represented by release_id

--- a/app/repository.py
+++ b/app/repository.py
@@ -57,6 +57,7 @@ class GraphRepository():
         else:
             return self._adapter.generate_artist(artist_response)
 
+    # Used for auto-complete feature
     def get_artists_by_string(self, querystring: str) -> Artist:
         """get_artists_by_string
 

--- a/app/repository.py
+++ b/app/repository.py
@@ -42,6 +42,42 @@ class GraphRepository():
         else:
             return self._adapter.generate_artist(artist_response)
 
+    def get_artist_by_name(self, artist_name: str) -> Artist:
+        """get_artist_by_name
+
+        :param artist_name: name of the artist to search up
+        :type artist_name: str
+        :rtype: Artist
+        """
+
+        artist_response = self._matcher.match("Artist", name=artist_name)
+
+        if artist_response is None:
+            return None
+        else:
+            return self._adapter.generate_artist(artist_response)
+
+    def get_artists_by_string(self, querystring: str) -> Artist:
+        """get_artists_by_string
+
+        returns the first 5 artists matching the querystring
+
+        :param querystring: the string to match on database search
+        :type querystring: str
+        :rtype: List of Artist
+        """
+
+        artists_response = self._matcher.match("Artist").where("_.name =~ '{querystring}*'").order_by("_.name").limit(5)
+        print("REPOSITORY TIME")
+        print(artists_response)
+        pdb.set_trace()
+        if artists_response is None:
+            return None
+        else:
+            #TODO ITERATE THROUGH THE ARTISTS RESPONSE
+            #see neo4j docs for iter()
+            return self._adapter.generate_artists_list(artists_response)
+
     def get_path_by_id(self, artist_id_one: str, artist_id_two: str) -> Path:
         """get_path_by_id
 


### PR DESCRIPTION
API now supports searching for a musician by passing in a string representing a partial name. 

E.g. `artists/search/ABB` should return a list of artists matching that name, limited by 5. 